### PR TITLE
ExtraPatches: Skip splashscreens

### DIFF
--- a/Patcher/EDF41/ExtraPatches/NoSplashscreens.txt
+++ b/Patcher/EDF41/ExtraPatches/NoSplashscreens.txt
@@ -1,0 +1,7 @@
+; Author: metoxys
+; Skips all logos on game startup, launches the game straight into the title screen
+
+aob isDisplayLogo 40 53 48 83 EC 50 48 C7 44 24 20 FE FF FF FF 48 8B 05 8A 75 8E 00
+
+isDisplayLogo:
+B0 01 C3

--- a/Patcher/EDF5/ExtraPatches/NoSplashscreens.txt
+++ b/Patcher/EDF5/ExtraPatches/NoSplashscreens.txt
@@ -1,0 +1,24 @@
+; Author: metoxys
+; Skips all logos on game startup, launches the game straight into the title screen
+; This is achieved by intercepting at the exact point where MAINSCRIPT.AS is in memory and literally overwriting the "CompanyLogo();" calls with a no-op
+
+aob companyLogoHook 4C 8B CB 44 8B C5 48 8B D6
+alloc overwrite 46 companyLogoHook
+
+overwrite:
+48 81 FD B6 8F 00 00 ; cmp rbp,0000000000008FB6
+75 12 ; jne original
+66 C7 86 19 12 00 00 2F 2F ; mov word ptr [rsi+1219],2F2F
+66 C7 86 C7 1D 00 00 2F 2F ; mov word ptr [rsi+1DC7],2F2F
+; original:
+4C 8B CB ; mov r9,rbx
+44 8B C5 ; mov r8d,ebp
+48 8B D6 ; mov rdx,rsi
+48 8D 4C 24 40 ; lea rcx,[rsp+40]
+E9
+rel32! companyLogoHook+E
+
+companyLogoHook:
+E9
+rel32! overwrite
+90 90 90 90 90 90 90 90 90

--- a/Patcher/EDF6/ExtraPatches/NoSplashscreens.txt
+++ b/Patcher/EDF6/ExtraPatches/NoSplashscreens.txt
@@ -1,0 +1,23 @@
+; Author: metoxys
+; Skips all logos on game startup, launches the game straight into the title screen
+; This is achieved by intercepting at the exact point where MAINSCRIPT.AS is in memory and literally commenting out the "CompanyLogo();" call
+
+aob companyLogoHook 44 8B CE 4D 8B C6 48 8B D0 48 8B CB E8 90 9F B7 00
+alloc overwrite 35 companyLogoHook
+
+overwrite:
+81 FE D2 DD 00 00 ; cmp esi,0000DDD2
+75 0A ; jne original
+66 41 C7 86 F8 2E 00 00 2F 2F ; mov word ptr [r14+2EF8],2F2F
+; original:
+44 8B CE ; mov r9d,esi
+4D 8B C6 ; mov r8,r14
+48 8B D0 ; mov rdx,rax
+48 8B CB ; mov rcx,rbx
+E9
+rel32! companyLogoHook+C
+
+companyLogoHook:
+E9
+rel32! overwrite
+90 90 90 90 90 90 90


### PR DESCRIPTION
EDF 4.1 variant hijacks a "has this logo been seen yet?" function to always go "yes", thus skipping playback.  
EDF 5 & 6 variants intercepts the point where MAINSCRIPT.AS is in RAM, about to be compiled, and literally comments out the `CompanyLogo();` instructions, thus completely skipping that part of game initialization.  